### PR TITLE
improve elapsed time for published news

### DIFF
--- a/src/components/Widgets.svelte
+++ b/src/components/Widgets.svelte
@@ -6,7 +6,7 @@
   const time_elapsed_toString = (publishTime) => {
     const etime = (Date.now() - publishTime) / 1000;
     if (etime < 0) return "-";
-    if (etime < 60) return "الآن";
+    if (etime < 60) return "now";
 
     const a = {
       31536000: "year",

--- a/src/components/Widgets.svelte
+++ b/src/components/Widgets.svelte
@@ -3,6 +3,32 @@
   import { fly } from "svelte/transition";
   import { date } from "../store";
 
+  const time_elapsed_toString = (publishTime) => {
+    const etime = (Date.now() - publishTime) / 1000;
+    if (etime < 0) return "-";
+    if (etime < 60) return "الآن";
+
+    const a = {
+      31536000: "year",
+      2592000: "month",
+      86400: "day",
+      3600: "hour",
+      60: "min",
+    };
+
+    let output = "";
+
+    for (const [secs, str] of Object.entries(a).reverse()) {
+      const d = etime / Number(secs);
+      if (d >= 1) {
+        let r = Math.round(d);
+        output = r + " " + (r > 1 ? str + "s" : str) + " ago";
+        break;
+      }
+    }
+    return output;
+  };
+
   const getNews = (async () => {
     const res = await fetch(
       "https://github.win11react.com/api-cache/news.json"
@@ -33,8 +59,7 @@
               <h3>{n.title.split("-").slice(0, -1).join("-")}</h3>
               <p>
                 {n.source.name} &bull;
-                {Math.round((Date.now() - Date.parse(n.publishedAt)) / 3600000)}
-                hours ago
+                {time_elapsed_toString(Date.parse(n.publishedAt))}
               </p>
             </a>
           {/if}{/each}
@@ -52,8 +77,7 @@
           >
             <p>
               {n.source.name} &bull;
-              {Math.round((Date.now() - Date.parse(n.publishedAt)) / 3600000)} hours
-              ago
+              {time_elapsed_toString(Date.parse(n.publishedAt))}
             </p>
             <h3>{n.title.split("-").slice(0, -1).join("-")}</h3>
           </a>


### PR DESCRIPTION
Make elapsed time for published news more generic instead of showing it just in hours

![image](https://github.com/yashash-pugalia/win11-svelte/assets/32222578/984b5f8f-e487-4387-9f23-332750023993)
